### PR TITLE
Adds CurrencySelector and localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,13 @@ const {sanityData} = useSanityQuery({
       slug.current == $handle
     }
   `,
-  params: {handle},
+  shopifyVariables: {
+      country: country.isoCode
+    },
+  params: {
+    country: country.isoCode,
+    slug: handle,
+  },
   // No need to query Shopify product data
   getProductGraphQLFragment: () => false,
 });

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "focus-trap-react": "^8.8.1",
     "graphql-tag": "^2.12.4",
     "groq": "^2.15.0",
-    "hydrogen-plugin-sanity": "^0.1.1",
+    "hydrogen-plugin-sanity": "^0.2.0",
     "nocache": "^3.0.1",
     "pluralize": "^8.0.0",
     "react": "18.0.0-alpha-e6be2d531",

--- a/src/components/CurrencySelector.client.jsx
+++ b/src/components/CurrencySelector.client.jsx
@@ -1,0 +1,89 @@
+import {Fragment, useCallback} from 'react';
+import {useAvailableCountries, useCountry} from '@shopify/hydrogen/client';
+import {Listbox, Transition} from '@headlessui/react';
+
+export default function CurrencySelector() {
+
+  const countries = useAvailableCountries();
+  const [selectedCountry, setSelectedCountry] = useCountry();
+
+  const setCountry = useCallback(
+    (isoCode) => {
+      setSelectedCountry(
+        countries.find((country) => country.isoCode === isoCode),
+      );
+    },
+    [countries, setSelectedCountry],
+  );
+
+  if (countries.length === 1) {
+    return <></>
+  }
+
+  return (
+    <div className="relative">
+      <Listbox value={selectedCountry} onChange={setCountry}>
+        {({open}) => (
+          <>
+            <Listbox.Button>{selectedCountry.currency.isoCode}</Listbox.Button>
+
+            <Transition
+              show={open}
+              as={Fragment}
+              leave="transition ease-in duration-100"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <Listbox.Options className="absolute -mt-2 -ml-2 border border-black -top-px -left-px bg-offWhite">
+                {countries.map((country) => {
+                  const isSelected =
+                    country.isoCode === selectedCountry.isoCode;
+                  return (
+                    <Listbox.Option
+                      key={country.isoCode}
+                      value={country.isoCode}
+                    >
+                      {({active}) => (
+                        <div
+                          className={`p-2 flex justify-between items-center text-left w-full cursor-pointer ${
+                            isSelected ? 'font-medium' : null
+                          } ${active ? 'bg-paleGreen' : null}`}
+                        >
+                          <span className="mr-1">
+                            {country.currency.isoCode}
+                          </span>
+                          {isSelected ? <CheckIcon /> : null}
+                        </div>
+                      )}
+                    </Listbox.Option>
+                  );
+                })}
+              </Listbox.Options>
+            </Transition>
+          </>
+        )}
+      </Listbox>
+    </div>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="10"
+      height="8"
+      viewBox="0 0 10 8"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1.11043 3.56068L3.23175 5.682L3.93885 6.38911L3.23175 7.09621L0.40332 4.26779L1.11043 3.56068Z"
+        fill="#181806"
+      />
+      <path
+        d="M8.8886 0.0251465L9.59571 0.732253L3.23175 7.09621L2.52464 6.38911L3.23175 5.682L8.8886 0.0251465Z"
+        fill="#181806"
+      />
+    </svg>
+  );
+}

--- a/src/components/Header.server.jsx
+++ b/src/components/Header.server.jsx
@@ -9,7 +9,7 @@ export default function Header() {
 
   return (
     <header
-      className="backdrop-filter backdrop-blur-lg bg-opacity-80 bg-white border-b border-black flex items-start justify-between h-20 p-4 sticky top-0 w-full z-50"
+      className="sticky top-0 z-50 flex items-start justify-between w-full h-20 p-4 bg-white border-b border-black backdrop-filter backdrop-blur-lg bg-opacity-80"
       role="banner"
     >
       <div className="">
@@ -19,6 +19,7 @@ export default function Header() {
           </Link>
         </div>
         {data?.menu?.links && <HeaderMenu links={data.menu.links} />}
+        
       </div>
       <CartToggleButton />
     </header>

--- a/src/components/HeaderMenu.client.jsx
+++ b/src/components/HeaderMenu.client.jsx
@@ -2,6 +2,7 @@ import {ChevronDownIcon} from '@heroicons/react/outline';
 import {Popover} from '@headlessui/react';
 import {Link} from '@shopify/hydrogen/client';
 import clsx from 'clsx';
+import CurrencySelector from './CurrencySelector.client';
 
 const renderLinks = (links, close) => {
   return links?.map((link) => {
@@ -23,9 +24,9 @@ const renderLinks = (links, close) => {
                 />
               </Popover.Button>
 
-              <Popover.Panel className="absolute -m-px -ml-4 transform top-10 left-0 z-10">
+              <Popover.Panel className="absolute left-0 z-10 -m-px -ml-4 transform top-10">
                 <div className="overflow-hidden border border-black">
-                  <div className="backdrop-filter backdrop-blur-lg bg-opacity-80 bg-white gap-2 grid grid-cols-1 px-4 py-2 relative w-56">
+                  <div className="relative grid w-56 grid-cols-1 gap-2 px-4 py-2 bg-white backdrop-filter backdrop-blur-lg bg-opacity-80">
                     {link?.links && renderLinks(link.links, close)}
                   </div>
                 </div>
@@ -77,5 +78,6 @@ export default function HeaderMenu(props) {
     return null;
   }
 
-  return <div className="flex gap-4">{renderLinks(links)}</div>;
+  return <div className="flex gap-4">{renderLinks(links)}
+  <CurrencySelector /></div>;
 }

--- a/src/pages/collections/[handle].server.jsx
+++ b/src/pages/collections/[handle].server.jsx
@@ -17,7 +17,6 @@ export default function Collection() {
       country: country.isoCode
     },
     params: {
-      country: country.isoCode,
       slug: handle,
     },
   });

--- a/src/pages/collections/[handle].server.jsx
+++ b/src/pages/collections/[handle].server.jsx
@@ -13,7 +13,11 @@ export default function Collection() {
   const {handle} = useParams();
   const {sanityData: sanityCollection, shopifyProducts} = useSanityQuery({
     query: QUERY,
+    shopifyVariables: {
+      country: country.isoCode
+    },
     params: {
+      country: country.isoCode,
       slug: handle,
     },
   });
@@ -27,7 +31,7 @@ export default function Collection() {
       <div className="p-4">
         <div className="mb-20">
           {/* Title */}
-          <h1 className="font-medium text-3xl">
+          <h1 className="text-3xl font-medium">
             {sanityCollection.title}{' '}
             <span className="font-normal text-gray-400">
               (
@@ -42,7 +46,7 @@ export default function Collection() {
 
           {/* Description */}
           {sanityCollection?.description && (
-            <div className="font-normal max-w-3xl text-gray-500 text-3xl">
+            <div className="max-w-3xl text-3xl font-normal text-gray-500">
               {sanityCollection.description}
             </div>
           )}

--- a/src/pages/editorial/[handle].server.jsx
+++ b/src/pages/editorial/[handle].server.jsx
@@ -20,7 +20,6 @@ export default function EditorialArticle() {
       country: country.isoCode
     },
     params: {
-      country: country.isoCode,
       slug: handle,
     },
   });

--- a/src/pages/editorial/[handle].server.jsx
+++ b/src/pages/editorial/[handle].server.jsx
@@ -16,7 +16,11 @@ export default function EditorialArticle() {
 
   const {sanityData: sanityArticle, shopifyProducts} = useSanityQuery({
     query: QUERY,
+    shopifyVariables: {
+      country: country.isoCode
+    },
     params: {
+      country: country.isoCode,
       slug: handle,
     },
   });
@@ -29,7 +33,7 @@ export default function EditorialArticle() {
     <ProductsProvider value={shopifyProducts}>
       <Layout>
         <div className="max-w-3xl p-4">
-          <h1 className="font-medium mb-10 text-3xl">{sanityArticle.title}</h1>
+          <h1 className="mb-10 text-3xl font-medium">{sanityArticle.title}</h1>
 
           {/* Body */}
           {sanityArticle?.body && (

--- a/src/pages/products/[handle].server.jsx
+++ b/src/pages/products/[handle].server.jsx
@@ -19,7 +19,6 @@ export default function Product(props) {
       country: country.isoCode
     },
     params: {
-      country: country.isoCode,
       slug: handle,
     },
   });

--- a/src/pages/products/[handle].server.jsx
+++ b/src/pages/products/[handle].server.jsx
@@ -11,10 +11,15 @@ import {PRODUCT_PAGE} from '../../fragments/productPage';
 import {encode} from '../../utils/shopifyGid';
 
 export default function Product(props) {
-  const {handle} = useParams();
+  const { handle } = useParams();
+  const {country = {isoCode: ''}} = props;
   const {sanityData: sanityProduct, shopifyProducts} = useSanityQuery({
     query: QUERY,
+    shopifyVariables: {
+      country: country.isoCode
+    },
     params: {
+      country: country.isoCode,
       slug: handle,
     },
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3063,10 +3063,10 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-hydrogen-plugin-sanity@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/hydrogen-plugin-sanity/-/hydrogen-plugin-sanity-0.1.1.tgz#efca7536c7e3d30484ae2bc47cf53f7b0e4ce652"
-  integrity sha512-sWeO5/nq7u/vTe8W2HofrGJ1ychZbYEQP8SLaWoKHEMvIKNkhdsnZW7ZtjDC1zXJAh6W+oYKO+mDoBIVLyWqMA==
+hydrogen-plugin-sanity@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/hydrogen-plugin-sanity/-/hydrogen-plugin-sanity-0.2.0.tgz#52590c54a643e6fd8b99543bdc33757ef867e63c"
+  integrity sha512-qk+k10UDBfeCDrkxtT1/a9OxLgj8MCDBCo676lqZeJPGLIW0QZhhEXAA22pNZddKxFY0mArjaqz/cJp3UZym6w==
 
 hyperscript@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
To take advantage of the updates to the plugin (https://github.com/sanity-io/hydrogen-plugin-sanity/pull/2), this PR adds a simple currency selector (which renders when AvailableCountries > 1), and updates the product queries to be localized by passing the country code to `shopifyVariables`.