### PR TITLE
Remove `JSON.stringify` from query key

### DIFF
--- a/src/hooks/useSanityQuery.ts
+++ b/src/hooks/useSanityQuery.ts
@@ -19,7 +19,7 @@ export default function useSanityQuery<T>({
   params = {},
 }: Props) {
   return useQuery<T>(
-    JSON.stringify([query, params]),
+    [query, params],
     async () => await client.fetch(query, params),
     hydrogenQueryOptions,
   );


### PR DESCRIPTION
Instead of stringify-ing before passing to `useQuery`, rely on [useQuery's key hashing](https://github.com/Shopify/hydrogen/blob/main/packages/hydrogen/src/utilities/hash.ts).