### PR TITLE
fix: 'scriptjs' error

### DIFF
--- a/src/components/modules/Instagram.client.tsx
+++ b/src/components/modules/Instagram.client.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useState} from 'react';
-import {InstagramEmbed} from 'react-social-media-embed';
+import {InstagramEmbed} from 'react-social-media-embed/dist/components/embeds/InstagramEmbed';
 import type {SanityModuleInstagram} from '../../types';
 
 export default function InstagramModule({


### PR DESCRIPTION
Unused portions of react-social-media-embed are causing an error. Skipping over them and sourcing directly from InstagramEmbed fixes the build error: ERROR: Could not resolve "scriptjs"