### PR TITLE
chore: adjust cart shipping message

### DIFF
--- a/src/components/cart/Cart.client.tsx
+++ b/src/components/cart/Cart.client.tsx
@@ -271,8 +271,8 @@ function CartFooter() {
             <span className="text-darkGray" role="rowheader">
               Shipping
             </span>
-            <span role="cell" className="font-bold uppercase">
-              Free
+            <span role="cell" className="font-bold">
+              Calculated at checkout
             </span>
           </div>
         </div>


### PR DESCRIPTION
Feedback following Sanity product day hackathon - remove "free shipping" message in cart. Could be a gotcha. Updated to reflect unknown shipping costs.