### PR TITLE
feat: setup live preview

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,11 +1,24 @@
 # These variables are only available locally in MiniOxygen
+# https://shopify.dev/docs/custom-storefronts/hydrogen/environment-variables
 
+## Shopify Environment Variables
+# A secret used to sign session cookies.
 SESSION_SECRET="foobar"
+# The public access token for the Storefront API.
 PUBLIC_STOREFRONT_API_TOKEN=""
+# (Optional) The Storefront API version.
+# Defaults to the version of the Storefront API used by Hydrogen.
 PUBLIC_STOREFRONT_API_VERSION="2023-01"
+# The domain of the store used to communicate with the Storefront API.
 PUBLIC_STORE_DOMAIN=""
 
+## Sanity Environment Variables
+# Project ID
 SANITY_PROJECT_ID=""
+# Dataset name
 SANITY_DATASET=""
+# (Optional) Sanity API version
 SANITY_API_VERSION=""
+# Sanity token to authenticate requests in "preview" mode
+# https://www.sanity.io/docs/http-auth
 SANITY_API_TOKEN=""

--- a/.env.template
+++ b/.env.template
@@ -22,3 +22,5 @@ SANITY_API_VERSION=""
 # Sanity token to authenticate requests in "preview" mode
 # https://www.sanity.io/docs/http-auth
 SANITY_API_TOKEN=""
+# Secret for authenticating preview mode
+SANITY_PREVIEW_SECRET=""

--- a/app/lib/preview.tsx
+++ b/app/lib/preview.tsx
@@ -1,0 +1,71 @@
+import {definePreview, type Params, PreviewSuspense} from '@sanity/preview-kit';
+import {createContext, type ReactNode, useContext} from 'react';
+
+const PreviewContext = createContext<PreviewContext | undefined>(undefined);
+
+export const usePreviewContext = () => useContext(PreviewContext);
+
+/**
+ * Conditionally apply `PreviewSuspense` boundary
+ * @see https://www.sanity.io/docs/preview-content-on-site
+ */
+export function Preview(props: PreviewProps) {
+  const {children, preview} = props;
+
+  if (!preview) {
+    return <>{children}</>;
+  }
+
+  const fallback = props.fallback ?? <div>Loading preview...</div>;
+  const {projectId, dataset, token} = preview;
+  const _usePreview = definePreview({
+    projectId,
+    dataset,
+    overlayDrafts: true,
+  });
+
+  function usePreview<
+    R = any,
+    P extends Params = Params,
+    Q extends string = string,
+  >(query: Q, params?: P, serverSnapshot?: R): R {
+    return _usePreview(token, query, params, serverSnapshot);
+  }
+  usePreview satisfies UsePreview;
+
+  return (
+    <PreviewContext.Provider value={{usePreview}}>
+      <PreviewSuspense fallback={fallback}>{children}</PreviewSuspense>
+    </PreviewContext.Provider>
+  );
+}
+
+type UsePreview = <
+  R = any,
+  P extends Params = Params,
+  Q extends string = string,
+>(
+  query: Q,
+  params?: P,
+  serverSnapshot?: R,
+) => R;
+
+type PreviewData = {
+  projectId: string;
+  dataset: string;
+  token: string;
+};
+
+type PreviewContext = {
+  /**
+   * Query Sanity and subscribe to changes, optionally
+   * passing a server snapshot to speed up hydration
+   */
+  usePreview: UsePreview;
+};
+
+type PreviewProps = {
+  children: ReactNode;
+  fallback?: ReactNode;
+  preview?: PreviewData;
+};

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -33,6 +33,7 @@ import {Layout} from '~/components/global/Layout';
 import {NotFound} from '~/components/global/NotFound';
 import {useAnalytics} from '~/hooks/useAnalytics';
 import {useNonce} from '~/lib/nonce';
+import {Preview} from '~/lib/preview';
 import {DEFAULT_LOCALE} from '~/lib/utils';
 import {LAYOUT_QUERY} from '~/queries/sanity/layout';
 import {CART_QUERY} from '~/queries/shopify/cart';
@@ -98,7 +99,7 @@ export async function loader({context}: LoaderArgs) {
       shopId: shop.shop.id,
     },
     cart: cartId ? getCart(context, cartId) : undefined,
-    isPreview: context.sanity.isPreview,
+    preview: context.sanity.preview,
     layout,
     notFoundCollection: layout.notFoundPage?.collectionGid
       ? context.storefront.query<{collection: Collection}>(
@@ -119,7 +120,7 @@ export async function loader({context}: LoaderArgs) {
 }
 
 export default function App() {
-  const {isPreview, ...data} = useLoaderData<typeof loader>();
+  const {preview, ...data} = useLoaderData<typeof loader>();
   const locale = data.selectedLocale ?? DEFAULT_LOCALE;
   const hasUserConsent = true;
   const nonce = useNonce();
@@ -134,7 +135,7 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <Preview enabled={isPreview}>
+        <Preview preview={preview}>
           <Layout key={`${locale.language}-${locale.country}`}>
             <Outlet />
           </Layout>
@@ -234,21 +235,4 @@ async function getCart({storefront}: AppLoadContext, cartId: string) {
   });
 
   return cart;
-}
-
-/**
- * @todo move elsewhere
- */
-type PreviewProps = {children: ReactNode; enabled: boolean};
-
-function Preview(props: PreviewProps) {
-  const {children, enabled} = props;
-
-  return enabled ? (
-    <PreviewSuspense fallback={<div>Loading preview...</div>}>
-      {children}
-    </PreviewSuspense>
-  ) : (
-    <>{children}</>
-  );
 }

--- a/app/routes/api/preview.tsx
+++ b/app/routes/api/preview.tsx
@@ -1,0 +1,70 @@
+import {
+  type ActionFunction,
+  json,
+  type LoaderFunction,
+  redirect,
+} from '@shopify/remix-oxygen';
+
+const ROOT_PATH = '/' as const;
+
+/**
+ * A `POST` request to this route will exit preview mode
+ */
+export const action: ActionFunction = async ({request, context}) => {
+  if (request.method !== 'POST') {
+    return json({message: 'Method not allowed'}, 405);
+  }
+
+  const body = await request.formData();
+  let slug = (body.get('slug') as string) ?? ROOT_PATH;
+  slug = slug.startsWith(ROOT_PATH) ? slug : ROOT_PATH;
+
+  return redirect(slug, {
+    headers: {
+      'Set-Cookie': await context.sanity.previewSession.destroy(),
+    },
+  });
+};
+
+// TODO: more user-friendly errors?
+// export default <></>;
+
+/**
+ * A `GET` request to this route will enter preview mode
+ */
+export const loader: LoaderFunction = async function ({request, context}) {
+  const {env, sanity} = context;
+  const {searchParams} = new URL(request.url);
+
+  if (!searchParams.has('secret')) {
+    throw new MissingSecretError();
+  }
+
+  if (searchParams.get('secret') !== env.SANITY_PREVIEW_SECRET) {
+    throw new InvalidSecretError();
+  }
+
+  let slug = searchParams.get('slug') ?? ROOT_PATH;
+  slug = slug.startsWith(ROOT_PATH) ? slug : ROOT_PATH;
+
+  sanity.previewSession.set('projectId', env.SANITY_PROJECT_ID);
+
+  return redirect(slug, {
+    status: 307,
+    headers: {
+      'Set-Cookie': await sanity.previewSession.commit(),
+    },
+  });
+};
+
+class MissingSecretError extends Response {
+  constructor() {
+    super('Missing secret', {status: 401, statusText: 'Unauthorized'});
+  }
+}
+
+class InvalidSecretError extends Response {
+  constructor() {
+    super('Invalid secret', {status: 401, statusText: 'Unauthorized'});
+  }
+}

--- a/remix.env.d.ts
+++ b/remix.env.d.ts
@@ -6,7 +6,14 @@ import type {Storefront} from '~/types/shopify';
 import type {SanityClient} from '@sanity/client';
 import type {HydrogenSession} from '../server';
 
-type Sanity = {client: SanityClient; isPreview: boolean};
+type Sanity = {
+  client: SanityClient, 
+  preview?: {
+    projectId: string;
+    dataset: string;
+    token: string;
+  }
+};
 
 declare global {
   /**

--- a/remix.env.d.ts
+++ b/remix.env.d.ts
@@ -5,6 +5,7 @@
 import type {Storefront} from '~/types/shopify';
 import type {SanityClient} from '@sanity/client';
 import type {HydrogenSession} from '../server';
+import type { PreviewSession } from '~/lib/preview';
 
 type Sanity = {
   client: SanityClient, 
@@ -12,7 +13,8 @@ type Sanity = {
     projectId: string;
     dataset: string;
     token: string;
-  }
+  },
+  previewSession: PreviewSession,
 };
 
 declare global {
@@ -35,6 +37,7 @@ declare global {
     SANITY_DATASET: string;
     SANITY_API_VERSION: string;
     SANITY_API_TOKEN: string;
+    SANITY_PREVIEW_SECRET: string;
   }
 }
 

--- a/server.ts
+++ b/server.ts
@@ -11,6 +11,7 @@ import {
   type SessionStorage,
 } from '@shopify/remix-oxygen';
 
+import {PreviewSession} from '~/lib/preview';
 import {getLocaleFromRequest} from '~/lib/utils';
 
 /**
@@ -31,9 +32,10 @@ export default {
       }
 
       const waitUntil = (p: Promise<any>) => executionContext.waitUntil(p);
-      const [cache, session] = await Promise.all([
+      const [cache, session, previewSession] = await Promise.all([
         caches.open('hydrogen'),
         HydrogenSession.init(request, [env.SESSION_SECRET]),
+        PreviewSession.init(request, [env.SESSION_SECRET]),
       ]);
 
       /**
@@ -61,14 +63,14 @@ export default {
           apiVersion: env.SANITY_API_VERSION ?? '2023-03-30',
           useCdn: process.env.NODE_ENV === 'production',
         }),
+        previewSession,
       };
 
       /**
-       * @todo Check if running in preview mode
        * @todo naming
        * @todo test token?
        */
-      const isPreview = true;
+      const isPreview = previewSession.has('projectId');
       if (isPreview) {
         /**
          * Sanity API token to view draft documents


### PR DESCRIPTION
- provide configured Sanity client in context
- if in preview mode, wrap `Layout` with `PreviewSuspense`
- provide `PreviewContext` with `usePreview` hook for data-fetching components