### PR TITLE
feat: Add support for createWithCache_unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It's possible to make calls to the Sanity API either with `query`:
 
 ```tsx
 import {json, type LoaderArgs} from '@shopify/remix-oxygen';
-import type {SanityProductPage} from '~/types/sanity';
+import type {SanityProductPage} from '~/lib/sanity';
 
 const QUERY = `*[_type == 'product' && slug.current == $slug]`;
 
@@ -57,7 +57,7 @@ or directly with the Sanity client:
 // <root>/app/routes/($lang).products.$handle.tsx
 import {useLoaderData} from '@remix-run/react';
 import {json, type LoaderArgs} from '@shopify/remix-oxygen';
-import type {SanityProductPage} from '~/types/sanity';
+import type {SanityProductPage} from '~/lib/sanity';
 
 const QUERY = `*[_type == 'product' && slug.current == $slug]`;
 
@@ -87,7 +87,7 @@ You can also use the [`defer` and `Await` utilities](https://remix.run/docs/en/1
 import {Suspense} from 'react';
 import {Await, useLoaderData} from '@remix-run/react';
 import {defer, type LoaderArgs} from '@shopify/remix-oxygen';
-import type {SanityProductPage, LessImportant} from '~/types/sanity';
+import type {SanityProductPage, LessImportant} from '~/lib/sanity';
 
 const QUERY = `*[_type == 'product' && slug.current == $slug]`;
 const ANOTHER_QUERY = `*[references($id)]`;

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This TypeScript demo adopts many of Hydrogen's [framework conventions and third-
 
 This demo comes preconfigured with a Sanity client that is available in the Remix context, enabling you to fetch content from Sanity in Remix loaders and actions.
 
-In addition to this, we've created a `fetchWithCache` utility, which uses [Hydrogen's caching strategies](https://shopify.dev/docs/custom-storefronts/hydrogen/data-fetching/cache#caching-strategies) to reduce the number of calls to Sanity's API.
+In addition to this, we've created a `fetchWithCache` utility, which uses [Hydrogen's caching strategies](https://shopify.dev/docs/custom-storefronts/hydrogen/data-fetching/cache#caching-strategies) to reduce the number of calls to Sanity's API. If no straregy is provided to the `cache` option, then the Hydrogen `CacheLong()` strategy will be used by default.
 
 It's possible to make calls to the Sanity API either with `fetchWithCache`:
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ This TypeScript demo adopts many of Hydrogen's [framework conventions and third-
 
 This demo comes preconfigured with a Sanity client that is available in the Remix context, enabling you to fetch content from Sanity in Remix loaders and actions.
 
-In addition to this, we've created a `fetchWithCache` utility, which uses [Hydrogen's caching strategies](https://shopify.dev/docs/custom-storefronts/hydrogen/data-fetching/cache#caching-strategies) to reduce the number of calls to Sanity's API. If no straregy is provided to the `cache` option, then the Hydrogen `CacheLong()` strategy will be used by default.
+In addition to this, we've created a `query` utility, which uses [Hydrogen's caching strategies](https://shopify.dev/docs/custom-storefronts/hydrogen/data-fetching/cache#caching-strategies) to reduce the number of calls to Sanity's API. If no straregy is provided to the `cache` option, then the Hydrogen `CacheLong()` strategy will be used by default.
 
-It's possible to make calls to the Sanity API either with `fetchWithCache`:
+It's possible to make calls to the Sanity API either with `query`:
 
 ```tsx
 import {json, type LoaderArgs} from '@shopify/remix-oxygen';
@@ -39,7 +39,7 @@ const QUERY = `*[_type == 'product' && slug.current == $slug]`;
 export async function loader({params, context}: LoaderArgs) {
   const cache = context.storefront.CacheLong();
 
-  const sanityContent = await context.sanity.fetchWithCache<SanityProductPage>({
+  const sanityContent = await context.sanity.query<SanityProductPage>({
     query: QUERY,
     params: {
       slug: params.handle,
@@ -94,7 +94,7 @@ const ANOTHER_QUERY = `*[references($id)]`;
 
 export async function loader({params, context}: LoaderArgs) {
   /* Await the important content here */
-  const sanityContent = await context.sanity.fetchWithCache<SanityProductPage>({
+  const sanityContent = await context.sanity.query<SanityProductPage>({
     query: QUERY,
     params: {
       slug: params.handle,
@@ -102,7 +102,7 @@ export async function loader({params, context}: LoaderArgs) {
   });
 
   /* This can wait - so don't await it - keep it as a promise */
-  const moreSanityContent = context.sanity.fetchWithCache<LessImportant>({
+  const moreSanityContent = context.sanity.query<LessImportant>({
     query: ANOTHER_QUERY,
     params: {
       id: sanityContent._id,

--- a/README.md
+++ b/README.md
@@ -26,6 +26,33 @@ This TypeScript demo adopts many of Hydrogen's [framework conventions and third-
 
 This demo comes preconfigured with a Sanity client that is available in the Remix context, enabling you to fetch content from Sanity in Remix loaders and actions.
 
+In addition to this, we've created a `fetchWithCache` utility, which uses [Hydrogen's caching strategies](https://shopify.dev/docs/custom-storefronts/hydrogen/data-fetching/cache#caching-strategies) to reduce the number of calls to Sanity's API.
+
+It's possible to make calls to the Sanity API either with `fetchWithCache`:
+
+```tsx
+import {json, type LoaderArgs} from '@shopify/remix-oxygen';
+import type {SanityProductPage} from '~/types/sanity';
+
+const QUERY = `*[_type == 'product' && slug.current == $slug]`;
+
+export async function loader({params, context}: LoaderArgs) {
+  const cache = context.storefront.CacheLong();
+
+  const sanityContent = await context.sanity.fetchWithCache<SanityProductPage>({
+    query: QUERY,
+    params: {
+      slug: params.handle,
+    },
+    cache,
+  });
+
+  return json({sanityContent});
+}
+```
+
+or directly with the Sanity client:
+
 ```tsx
 // <root>/app/routes/($lang).products.$handle.tsx
 import {useLoaderData} from '@remix-run/react';
@@ -67,20 +94,20 @@ const ANOTHER_QUERY = `*[references($id)]`;
 
 export async function loader({params, context}: LoaderArgs) {
   /* Await the important content here */
-  const sanityContent = await context.sanity.client.fetch<SanityProductPage>(
-    QUERY,
-    {
+  const sanityContent = await context.sanity.fetchWithCache<SanityProductPage>({
+    query: QUERY,
+    params: {
       slug: params.handle,
     },
-  );
+  });
 
   /* This can wait - so don't await it - keep it as a promise */
-  const moreSanityContent = context.sanity.client.fetch<LessImportant>(
-    ANOTHER_QUERY,
-    {
+  const moreSanityContent = context.sanity.fetchWithCache<LessImportant>({
+    query: ANOTHER_QUERY,
+    params: {
       id: sanityContent._id,
     },
-  );
+  });
 
   return defer({sanityContent});
 }

--- a/app/components/collection/Card.tsx
+++ b/app/components/collection/Card.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 
 import {Link} from '~/components/Link';
-import type {SanityCollection} from '~/types/sanity';
+import type {SanityCollection} from '~/lib/sanity';
 
 type Props = {
   collection: SanityCollection;

--- a/app/components/collection/ProductGrid.tsx
+++ b/app/components/collection/ProductGrid.tsx
@@ -6,8 +6,8 @@ import {useEffect, useState} from 'react';
 import Button from '~/components/elements/Button';
 import SpinnerIcon from '~/components/icons/Spinner';
 import ModuleGrid from '~/components/modules/ModuleGrid';
+import {SanityColorTheme, SanityModule} from '~/lib/sanity';
 import {combineProductsAndModules} from '~/lib/utils';
-import {SanityColorTheme, SanityModule} from '~/types/sanity';
 
 export default function ProductGrid({
   collection,

--- a/app/components/elements/Link.tsx
+++ b/app/components/elements/Link.tsx
@@ -1,7 +1,7 @@
 import type {HTMLAttributes} from 'react';
 
 import {Link as HydrogenLink} from '~/components/Link';
-import type {SanityLink} from '~/types/sanity';
+import type {SanityLink} from '~/lib/sanity';
 
 type Props = {
   link: SanityLink;

--- a/app/components/elements/LinkButton.tsx
+++ b/app/components/elements/LinkButton.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 
 import {defaultButtonStyles} from '~/components/elements/Button';
 import Link from '~/components/elements/Link';
-import type {SanityLink} from '~/types/sanity';
+import type {SanityLink} from '~/lib/sanity';
 
 type Props = {
   backgroundColor?: string;

--- a/app/components/global/Footer.tsx
+++ b/app/components/global/Footer.tsx
@@ -5,7 +5,7 @@ import SanityFooter from '~/components/global/SanityFooter';
 import LogoIcon from '~/components/icons/Logo';
 import {Link} from '~/components/Link';
 import PortableText from '~/components/portableText/PortableText';
-import type {SanityLink} from '~/types/sanity';
+import type {SanityLink} from '~/lib/sanity';
 
 /**
  * A component that specifies the content of the footer on the website

--- a/app/components/global/MobileNavigation.tsx
+++ b/app/components/global/MobileNavigation.tsx
@@ -6,7 +6,7 @@ import {CountrySelector} from '~/components/global/CountrySelector';
 import CloseIcon from '~/components/icons/Close';
 import MenuIcon from '~/components/icons/Menu';
 import {Link} from '~/components/Link';
-import type {SanityMenuLink} from '~/types/sanity';
+import type {SanityMenuLink} from '~/lib/sanity';
 
 type Props = {
   menuLinks: SanityMenuLink[];

--- a/app/components/global/Navigation.tsx
+++ b/app/components/global/Navigation.tsx
@@ -3,7 +3,7 @@ import {useCallback} from 'react';
 
 import CollectionGroup from '~/components/global/collectionGroup/CollectionGroup';
 import {Link} from '~/components/Link';
-import type {SanityMenuLink} from '~/types/sanity';
+import type {SanityMenuLink} from '~/lib/sanity';
 
 /**
  * A component that defines the navigation for a web storefront

--- a/app/components/global/NotFound.tsx
+++ b/app/components/global/NotFound.tsx
@@ -4,7 +4,7 @@ import type {Collection} from '@shopify/hydrogen/storefront-api-types';
 import {Suspense} from 'react';
 
 import ProductPill, {PillSkeleton} from '~/components/product/Pill';
-import type {SanityNotFoundPage} from '~/types/sanity';
+import type {SanityNotFoundPage} from '~/lib/sanity';
 
 /**
  * A component that defines the content to display when a page isn't found (404 error)

--- a/app/components/global/collectionGroup/CollectionGroup.tsx
+++ b/app/components/global/collectionGroup/CollectionGroup.tsx
@@ -1,5 +1,5 @@
 import CollectionGroupDialog from '~/components/global/collectionGroup/CollectionGroupDialog';
-import type {SanityCollectionGroup} from '~/types/sanity';
+import type {SanityCollectionGroup} from '~/lib/sanity';
 
 type Props = {
   collectionGroup: SanityCollectionGroup;

--- a/app/components/global/collectionGroup/CollectionGroupContent.tsx
+++ b/app/components/global/collectionGroup/CollectionGroupContent.tsx
@@ -7,7 +7,7 @@ import {useInView} from 'react-intersection-observer';
 import CollectionCard from '~/components/collection/Card';
 import CloseIcon from '~/components/icons/Close';
 import ProductPill, {PillSkeleton} from '~/components/product/Pill';
-import type {SanityCollection, SanityCollectionGroup} from '~/types/sanity';
+import type {SanityCollection, SanityCollectionGroup} from '~/lib/sanity';
 
 type Props = {
   collection?: SanityCollection;

--- a/app/components/global/collectionGroup/CollectionGroupDialog.tsx
+++ b/app/components/global/collectionGroup/CollectionGroupDialog.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import {Fragment, useState} from 'react';
 
 import CollectionGroupContent from '~/components/global/collectionGroup/CollectionGroupContent';
-import type {SanityCollection, SanityCollectionGroup} from '~/types/sanity';
+import type {SanityCollection, SanityCollectionGroup} from '~/lib/sanity';
 
 export default function CollectionGroupDialog({
   collection,

--- a/app/components/heroes/Collection.tsx
+++ b/app/components/heroes/Collection.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 
 import HeroContent from '~/components/heroes/HeroContent';
-import type {SanityColorTheme, SanityHeroCollection} from '~/types/sanity';
+import type {SanityColorTheme, SanityHeroCollection} from '~/lib/sanity';
 
 type Props = {
   colorTheme?: SanityColorTheme;

--- a/app/components/heroes/HeroContent.tsx
+++ b/app/components/heroes/HeroContent.tsx
@@ -5,7 +5,7 @@ import ProductHero from '~/components/product/ProductHero';
 import type {
   SanityImageWithProductHotspots,
   SanityProductWithVariant,
-} from '~/types/sanity';
+} from '~/lib/sanity';
 
 type Props = {
   content?: SanityImageWithProductHotspots | SanityProductWithVariant;

--- a/app/components/heroes/Home.tsx
+++ b/app/components/heroes/Home.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 
 import LinkButton from '~/components/elements/LinkButton';
 import HeroContent from '~/components/heroes/HeroContent';
-import type {SanityHeroHome} from '~/types/sanity';
+import type {SanityHeroHome} from '~/lib/sanity';
 
 type Props = {
   hero: SanityHeroHome;

--- a/app/components/heroes/Page.tsx
+++ b/app/components/heroes/Page.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 
 import HeroContent from '~/components/heroes/HeroContent';
-import type {SanityColorTheme, SanityHeroPage} from '~/types/sanity';
+import type {SanityColorTheme, SanityHeroPage} from '~/lib/sanity';
 
 type Props = {
   colorTheme?: SanityColorTheme;

--- a/app/components/media/ImageWithProductHotspots.tsx
+++ b/app/components/media/ImageWithProductHotspots.tsx
@@ -3,7 +3,7 @@ import {Product} from '@shopify/hydrogen/storefront-api-types';
 
 import SanityImage from '~/components/media/SanityImage';
 import ProductHotspot from '~/components/product/Hotspot';
-import type {SanityImageWithProductHotspots} from '~/types/sanity';
+import type {SanityImageWithProductHotspots} from '~/lib/sanity';
 
 type Props = {
   content: SanityImageWithProductHotspots;

--- a/app/components/media/SanityImage.tsx
+++ b/app/components/media/SanityImage.tsx
@@ -4,23 +4,30 @@ import imageUrlBuilder from '@sanity/image-url';
 
 const BREAKPOINTS = [640, 768, 1024, 1280, 1536]; // px
 
+// @ts-expect-error
 export const findLastNonNullValue = (items, currentIndex) => {
   const sliced = items.slice(0, currentIndex);
+  // @ts-expect-error
   return sliced.filter((val) => val !== null).pop();
 };
 
+// @ts-expect-error
 const generateSrcSet = (urlBuilder, breakpoints, {quality}) => {
-  return breakpoints
-    .map((width) => {
-      return `${urlBuilder
-        .width(width)
-        .auto('format')
-        .quality(quality)} ${width}w`;
-    })
-    .join(', ');
+  return (
+    breakpoints
+      // @ts-expect-error
+      .map((width) => {
+        return `${urlBuilder
+          .width(width)
+          .auto('format')
+          .quality(quality)} ${width}w`;
+      })
+      .join(', ')
+  );
 };
 
 // Generate srcset sizes based off breakpoints
+// @ts-expect-error
 const generateSizes = (breakpoints, sizes) => {
   if (!sizes) {
     return undefined;
@@ -34,25 +41,29 @@ const generateSizes = (breakpoints, sizes) => {
     return sizes[0];
   }
 
-  return sizes
-    .map((val, i) => {
-      if (i === sizes.length - 1) {
-        return sizes[i];
-      }
+  return (
+    sizes
+      // @ts-expect-error
+      .map((val, i) => {
+        if (i === sizes.length - 1) {
+          return sizes[i];
+        }
 
-      let current = val;
-      if (val === null) {
-        current = findLastNonNullValue(sizes, i);
-      }
+        let current = val;
+        if (val === null) {
+          current = findLastNonNullValue(sizes, i);
+        }
 
-      return `(max-width: ${breakpoints?.[i]}px) ${current}`;
-    })
-    .join(', ');
+        return `(max-width: ${breakpoints?.[i]}px) ${current}`;
+      })
+      .join(', ')
+  );
 };
 
 /**
  * A simple image component that wraps around `@sanity/image-url`
  */
+// @ts-expect-error
 export default function SanityImage(props) {
   const {
     // blurDataURL,
@@ -121,6 +132,7 @@ export default function SanityImage(props) {
   if (options?.blur) {
     urlDefault = urlDefault.blur(options.blur);
   }
+  // @ts-expect-error
   urlDefault = urlDefault.url();
 
   return (

--- a/app/components/modules/CallToAction.tsx
+++ b/app/components/modules/CallToAction.tsx
@@ -8,7 +8,7 @@ import type {
   SanityAssetImage,
   SanityModuleCallToAction,
   SanityProductWithVariant,
-} from '~/types/sanity';
+} from '~/lib/sanity';
 
 type Props = {
   module: SanityModuleCallToAction;

--- a/app/components/modules/Callout.tsx
+++ b/app/components/modules/Callout.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 
 import LinkButton from '~/components/elements/LinkButton';
-import type {SanityColorTheme, SanityModuleCallout} from '~/types/sanity';
+import type {SanityColorTheme, SanityModuleCallout} from '~/lib/sanity';
 
 type Props = {
   colorTheme?: SanityColorTheme;

--- a/app/components/modules/Collection.tsx
+++ b/app/components/modules/Collection.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 
 import Button from '~/components/elements/Button';
 import {Link} from '~/components/Link';
-import type {SanityModuleCollection} from '~/types/sanity';
+import type {SanityModuleCollection} from '~/lib/sanity';
 
 type Props = {
   module?: SanityModuleCollection;

--- a/app/components/modules/Image.tsx
+++ b/app/components/modules/Image.tsx
@@ -7,7 +7,7 @@ import Link from '~/components/elements/Link';
 import SanityImage from '~/components/media/SanityImage';
 import ProductHotspot from '~/components/product/Hotspot';
 import ProductTag from '~/components/product/Tag';
-import type {SanityModuleImage} from '~/types/sanity';
+import type {SanityModuleImage} from '~/lib/sanity';
 
 type Props = {
   module: SanityModuleImage;

--- a/app/components/modules/Instagram.tsx
+++ b/app/components/modules/Instagram.tsx
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react';
 import {InstagramEmbed} from 'react-social-media-embed/dist/components/embeds/InstagramEmbed';
 
-import type {SanityModuleInstagram} from '~/types/sanity';
+import type {SanityModuleInstagram} from '~/lib/sanity';
 
 export default function InstagramModule({
   module,

--- a/app/components/modules/Module.tsx
+++ b/app/components/modules/Module.tsx
@@ -4,7 +4,7 @@ import CollectionModule from '~/components/modules/Collection';
 import ImageModule from '~/components/modules/Image';
 import InstagramModule from '~/components/modules/Instagram';
 import ProductModule from '~/components/modules/Product';
-import type {SanityColorTheme, SanityModule} from '~/types/sanity';
+import type {SanityColorTheme, SanityModule} from '~/lib/sanity';
 
 type Props = {
   colorTheme?: SanityColorTheme;

--- a/app/components/modules/ModuleGrid.tsx
+++ b/app/components/modules/ModuleGrid.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 
 import Module from '~/components/modules/Module';
 import ProductCard from '~/components/product/Card';
-import type {SanityColorTheme, SanityModule} from '~/types/sanity';
+import type {SanityColorTheme, SanityModule} from '~/lib/sanity';
 import type {ProductWithNodes} from '~/types/shopify';
 
 // Sanity modules to render in full width (across all grid columns)

--- a/app/components/modules/Product.tsx
+++ b/app/components/modules/Product.tsx
@@ -3,7 +3,7 @@ import type {Product} from '@shopify/hydrogen/storefront-api-types';
 
 import ProductCard from '~/components/product/Card';
 import ProductPill from '~/components/product/Pill';
-import type {SanityModuleProduct} from '~/types/sanity';
+import type {SanityModuleProduct} from '~/lib/sanity';
 
 type Props = {
   imageAspectClassName?: string;

--- a/app/components/portableText/PortableText.tsx
+++ b/app/components/portableText/PortableText.tsx
@@ -17,7 +17,7 @@ import GridBlock from '~/components/portableText/blocks/Grid';
 import ImagesBlock from '~/components/portableText/blocks/Images';
 import InstagramBlock from '~/components/portableText/blocks/Instagram';
 import ProductsBlock from '~/components/portableText/blocks/Products';
-import type {SanityColorTheme} from '~/types/sanity';
+import type {SanityColorTheme} from '~/lib/sanity';
 
 const SHARED_LIST_CLASSES = clsx(
   'first:mt-0 last:mb-0', //

--- a/app/components/portableText/annotations/Product.tsx
+++ b/app/components/portableText/annotations/Product.tsx
@@ -3,7 +3,7 @@ import {useMatches} from '@remix-run/react';
 import type {Product} from '@shopify/hydrogen/storefront-api-types';
 
 import ProductInlineLink from '~/components/portableText/annotations/ProductInlineLink';
-import type {SanityColorTheme, SanityProductWithVariant} from '~/types/sanity';
+import type {SanityColorTheme, SanityProductWithVariant} from '~/lib/sanity';
 
 type Props = PortableTextMarkComponentProps & {
   colorTheme?: SanityColorTheme;

--- a/app/components/portableText/annotations/ProductInlineLink.tsx
+++ b/app/components/portableText/annotations/ProductInlineLink.tsx
@@ -11,7 +11,7 @@ import {Link} from '~/components/Link';
 import {AddToCartLink} from '~/components/product/buttons/AddToCartButton';
 import BuyNowButton from '~/components/product/buttons/BuyNowButton';
 import ProductTooltip from '~/components/product/Tooltip';
-import type {SanityColorTheme} from '~/types/sanity';
+import type {SanityColorTheme} from '~/lib/sanity';
 import type {ProductWithNodes} from '~/types/shopify';
 
 type Props = {

--- a/app/components/portableText/blocks/Accordion.tsx
+++ b/app/components/portableText/blocks/Accordion.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import MinusIcon from '~/components/icons/Minus';
 import PlusIcon from '~/components/icons/Plus';
 import PortableText from '~/components/portableText/PortableText';
-import type {SanityModuleAccordion} from '~/types/sanity';
+import type {SanityModuleAccordion} from '~/lib/sanity';
 
 type Props = {
   value: PortableTextBlock & SanityModuleAccordion;

--- a/app/components/portableText/blocks/Callout.tsx
+++ b/app/components/portableText/blocks/Callout.tsx
@@ -2,7 +2,7 @@ import type {PortableTextBlock} from '@portabletext/types';
 import clsx from 'clsx';
 
 import CalloutModule from '~/components/modules/Callout';
-import type {SanityColorTheme, SanityModuleCallout} from '~/types/sanity';
+import type {SanityColorTheme, SanityModuleCallout} from '~/lib/sanity';
 
 type Props = {
   centered?: boolean;

--- a/app/components/portableText/blocks/Grid.tsx
+++ b/app/components/portableText/blocks/Grid.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 
 import SanityImage from '~/components/media/SanityImage';
 import PortableText from '~/components/portableText/PortableText';
-import type {SanityModuleGrid} from '~/types/sanity';
+import type {SanityModuleGrid} from '~/lib/sanity';
 
 type Props = {
   value: PortableTextBlock & SanityModuleGrid;

--- a/app/components/portableText/blocks/Images.tsx
+++ b/app/components/portableText/blocks/Images.tsx
@@ -2,7 +2,7 @@ import type {PortableTextBlock} from '@portabletext/types';
 import clsx from 'clsx';
 
 import ImageModule from '~/components/modules/Image';
-import type {SanityModuleImages} from '~/types/sanity';
+import type {SanityModuleImages} from '~/lib/sanity';
 
 type Props = {
   centered?: boolean;

--- a/app/components/portableText/blocks/Instagram.tsx
+++ b/app/components/portableText/blocks/Instagram.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 
 import InstagramModule from '~/components/modules/Instagram';
-import type {SanityModuleInstagram} from '~/types/sanity';
+import type {SanityModuleInstagram} from '~/lib/sanity';
 
 type Props = {
   value: SanityModuleInstagram;

--- a/app/components/portableText/blocks/Products.tsx
+++ b/app/components/portableText/blocks/Products.tsx
@@ -2,7 +2,7 @@ import type {PortableTextBlock} from '@portabletext/types';
 import clsx from 'clsx';
 
 import ProductModule from '~/components/modules/Product';
-import type {SanityModuleProducts} from '~/types/sanity';
+import type {SanityModuleProducts} from '~/lib/sanity';
 
 type Props = {
   value: PortableTextBlock & SanityModuleProducts;

--- a/app/components/product/Details.tsx
+++ b/app/components/product/Details.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 
 import ProductGallery from '~/components/product/Gallery';
 import ProductWidget from '~/components/product/Widget';
-import type {SanityProductPage} from '~/types/sanity';
+import type {SanityProductPage} from '~/lib/sanity';
 
 type Props = {
   sanityProduct: SanityProductPage;

--- a/app/components/product/Form.tsx
+++ b/app/components/product/Form.tsx
@@ -11,8 +11,8 @@ import invariant from 'tiny-invariant';
 import AddToCartButton from '~/components/product/buttons/AddToCartButton';
 import BuyNowButton from '~/components/product/buttons/BuyNowButton';
 import ProductOptions from '~/components/product/Options';
+import {SanityCustomProductOption} from '~/lib/sanity';
 import {hasMultipleProductOptions} from '~/lib/utils';
-import {SanityCustomProductOption} from '~/types/sanity';
 
 export default function ProductForm({
   product,

--- a/app/components/product/Options.tsx
+++ b/app/components/product/Options.tsx
@@ -13,7 +13,7 @@ import clsx from 'clsx';
 import {forwardRef} from 'react';
 
 import Tooltip from '~/components/elements/Tooltip';
-import {SanityCustomProductOption} from '~/types/sanity';
+import {SanityCustomProductOption} from '~/lib/sanity';
 
 export default function ProductOptions({
   options,

--- a/app/components/product/RelatedProducts.tsx
+++ b/app/components/product/RelatedProducts.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 
 import ProductCard from '~/components/product/Card';
-import type {SanityColorTheme} from '~/types/sanity';
+import type {SanityColorTheme} from '~/lib/sanity';
 import type {ProductWithNodes} from '~/types/shopify';
 
 type Props = {

--- a/app/components/product/Widget.tsx
+++ b/app/components/product/Widget.tsx
@@ -3,8 +3,8 @@ import {Product, ProductVariant} from '@shopify/hydrogen/storefront-api-types';
 import clsx from 'clsx';
 
 import ProductForm from '~/components/product/Form';
+import type {SanityProductPage} from '~/lib/sanity';
 import {hasMultipleProductOptions} from '~/lib/utils';
-import type {SanityProductPage} from '~/types/sanity';
 
 type Props = {
   sanityProduct: SanityProductPage;

--- a/app/lib/preview.tsx
+++ b/app/lib/preview.tsx
@@ -6,11 +6,11 @@ import {
 } from '@shopify/remix-oxygen';
 import {
   createContext,
+  ElementType,
   type ReactElement,
   type ReactNode,
   useContext,
   useMemo,
-  ElementType,
 } from 'react';
 
 export class PreviewSession {

--- a/app/lib/sanity/client.ts
+++ b/app/lib/sanity/client.ts
@@ -1,0 +1,84 @@
+import {
+  type ClientConfig,
+  createClient,
+  type SanityClient,
+} from '@sanity/client';
+import {CacheLong, createWithCache_unstable} from '@shopify/hydrogen';
+
+import type {CachingStrategy, EnvironmentOptions} from '~/types/shopify';
+
+import type {PreviewData, PreviewSession} from './preview';
+
+type CreateSanityClientOptions = EnvironmentOptions & {
+  config: ClientConfig & Required<Pick<ClientConfig, 'projectId' | 'dataset'>>;
+  preview?: {
+    session: PreviewSession;
+    token: string;
+  };
+};
+
+type useSanityQuery = {
+  query: string;
+  params?: Record<string, unknown>;
+  cache?: CachingStrategy;
+};
+
+export type Sanity = {
+  client: SanityClient;
+  preview?:
+    | ({session: PreviewSession} & PreviewData)
+    | {session: PreviewSession};
+  query<T>(options: useSanityQuery): Promise<T>;
+};
+
+/**
+ * Create Sanity provider with API client.
+ */
+export function createSanityClient(options: CreateSanityClientOptions): Sanity {
+  const {cache, waitUntil, preview, config} = options;
+  const withCache = createWithCache_unstable({
+    cache,
+    waitUntil,
+  });
+
+  const sanity: Sanity = {
+    client: createClient(config),
+    query: ({query, params, cache = CacheLong()}) => {
+      // Prefix the cache key and make it unique based on arguments.
+      return withCache(['sanity', query, params], cache, () => {
+        return sanity.client.fetch(query, params);
+      });
+    },
+  };
+
+  if (preview) {
+    sanity.preview = {session: preview.session};
+
+    if (preview.session.has('projectId')) {
+      sanity.preview = {
+        ...sanity.preview,
+        projectId: config.projectId,
+        dataset: config.dataset,
+        token: preview.token,
+      };
+
+      sanity.client = sanity.client.withConfig({
+        useCdn: false,
+        token: preview.token,
+      });
+
+      sanity.query = ({query, params}) => {
+        return sanity.client.fetch(query, params);
+      };
+    }
+  }
+
+  return sanity;
+}
+
+export function isPreviewModeEnabled(
+  preview: Sanity['preview'],
+): preview is {session: PreviewSession} & PreviewData {
+  // @ts-expect-error
+  return preview?.token != null;
+}

--- a/app/lib/sanity/index.ts
+++ b/app/lib/sanity/index.ts
@@ -1,0 +1,3 @@
+export * from './client';
+export * from './preview';
+export * from './types';

--- a/app/lib/sanity/preview.tsx
+++ b/app/lib/sanity/preview.tsx
@@ -7,7 +7,6 @@ import {
 import {
   createContext,
   ElementType,
-  type ReactElement,
   type ReactNode,
   useContext,
   useMemo,
@@ -39,17 +38,17 @@ export class PreviewSession {
     return this.session.has(key);
   }
 
-  get(key: string) {
-    return this.session.get(key);
-  }
+  // get(key: string) {
+  //   return this.session.get(key);
+  // }
 
   destroy() {
     return this.sessionStorage.destroySession(this.session);
   }
 
-  unset(key: string) {
-    this.session.unset(key);
-  }
+  // unset(key: string) {
+  //   this.session.unset(key);
+  // }
 
   set(key: string, value: any) {
     this.session.set(key, value);
@@ -71,7 +70,7 @@ export const usePreviewContext = () => useContext(PreviewContext);
 export function Preview(props: PreviewProps) {
   const {children, preview} = props;
 
-  if (!preview) {
+  if (!preview?.token) {
     return <>{children}</>;
   }
 
@@ -109,7 +108,7 @@ type UsePreview = <
   serverSnapshot?: R,
 ) => R;
 
-type PreviewData = {
+export type PreviewData = {
   projectId: string;
   dataset: string;
   token: string;
@@ -123,7 +122,7 @@ type PreviewContext = {
   usePreview: UsePreview;
 };
 
-type PreviewProps = {
+export type PreviewProps = {
   children: ReactNode;
   fallback?: ReactNode;
   preview?: PreviewData;

--- a/app/lib/sanity/types.ts
+++ b/app/lib/sanity/types.ts
@@ -1,6 +1,6 @@
 import type {Image, PortableTextBlock} from '@sanity/types';
 
-import {ProductWithNodes} from './shopify';
+import {ProductWithNodes} from '~/types/shopify';
 
 export interface SanityAssetImage extends Image {
   _type: 'image';

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -10,14 +10,14 @@ import {reduceDeep} from 'deepdash-es/standalone';
 import pluralize from 'pluralize-esm';
 
 import {countries} from '~/data/countries';
-import {PRODUCTS_AND_COLLECTIONS} from '~/queries/shopify/product';
-import type {SanityModule} from '~/types/sanity';
+import type {SanityModule} from '~/lib/sanity';
 import type {
   SanityCollectionPage,
   SanityHomePage,
   SanityPage,
   SanityProductPage,
-} from '~/types/sanity';
+} from '~/lib/sanity';
+import {PRODUCTS_AND_COLLECTIONS} from '~/queries/shopify/product';
 import type {I18nLocale} from '~/types/shopify';
 
 export const DEFAULT_LOCALE: I18nLocale = Object.freeze({
@@ -199,7 +199,7 @@ export const getStorefrontData = async ({
   );
 
   const {products, collections}: StorefrontPayload =
-    await context.storefront.query(PRODUCTS_AND_COLLECTIONS, {
+    await context.storefront.query<any>(PRODUCTS_AND_COLLECTIONS, {
       variables: {
         ids: productGids,
         collectionIds: collectionGids,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -87,7 +87,7 @@ export async function loader({context}: LoaderArgs) {
   const [cartId, shop, layout] = await Promise.all([
     context.session.get('cartId'),
     context.storefront.query<{shop: Shop}>(SHOP_QUERY),
-    context.sanity.fetchWithCache({query: LAYOUT_QUERY, cache}),
+    context.sanity.query({query: LAYOUT_QUERY, cache}),
   ]);
 
   const selectedLocale = context.storefront.i18n as I18nLocale;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -31,7 +31,7 @@ import {Layout} from '~/components/global/Layout';
 import {NotFound} from '~/components/global/NotFound';
 import {useAnalytics} from '~/hooks/useAnalytics';
 import {useNonce} from '~/lib/nonce';
-import {Preview} from '~/lib/preview';
+import {isPreviewModeEnabled, Preview, PreviewData} from '~/lib/sanity';
 import {DEFAULT_LOCALE} from '~/lib/utils';
 import {LAYOUT_QUERY} from '~/queries/sanity/layout';
 import {CART_QUERY} from '~/queries/shopify/cart';
@@ -84,21 +84,31 @@ export async function loader({context}: LoaderArgs) {
     staleWhileRevalidate: 60,
   });
 
+  const preview: PreviewData | undefined = isPreviewModeEnabled(
+    context.sanity.preview,
+  )
+    ? {
+        projectId: context.sanity.preview.projectId,
+        dataset: context.sanity.preview.dataset,
+        token: context.sanity.preview.token,
+      }
+    : undefined;
+
   const [cartId, shop, layout] = await Promise.all([
     context.session.get('cartId'),
     context.storefront.query<{shop: Shop}>(SHOP_QUERY),
-    context.sanity.query({query: LAYOUT_QUERY, cache}),
+    context.sanity.query<any>({query: LAYOUT_QUERY, cache}),
   ]);
 
   const selectedLocale = context.storefront.i18n as I18nLocale;
 
   return defer({
+    preview,
     analytics: {
       shopifySalesChannel: ShopifySalesChannel.hydrogen,
       shopId: shop.shop.id,
     },
     cart: cartId ? getCart(context, cartId) : undefined,
-    preview: context.sanity.preview,
     layout,
     notFoundCollection: layout.notFoundPage?.collectionGid
       ? context.storefront.query<{collection: Collection}>(

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -78,10 +78,16 @@ export const links: LinksFunction = () => {
 };
 
 export async function loader({context}: LoaderArgs) {
+  const cache = context.storefront.CacheCustom({
+    mode: 'public',
+    maxAge: 60,
+    staleWhileRevalidate: 60,
+  });
+
   const [cartId, shop, layout] = await Promise.all([
     context.session.get('cartId'),
     context.storefront.query<{shop: Shop}>(SHOP_QUERY),
-    context.sanity.client.fetch(LAYOUT_QUERY),
+    context.sanity.fetchWithCache({query: LAYOUT_QUERY, cache}),
   ]);
 
   const selectedLocale = context.storefront.i18n as I18nLocale;

--- a/app/routes/($lang)._index.tsx
+++ b/app/routes/($lang)._index.tsx
@@ -30,7 +30,7 @@ export async function loader({context, params}: LoaderArgs) {
     staleWhileRevalidate: 60,
   });
 
-  const page = await context.sanity.fetchWithCache<SanityHomePage>({
+  const page = await context.sanity.query<SanityHomePage>({
     query: HOME_PAGE_QUERY,
     cache,
   });

--- a/app/routes/($lang)._index.tsx
+++ b/app/routes/($lang)._index.tsx
@@ -5,10 +5,10 @@ import clsx from 'clsx';
 
 import HomeHero from '~/components/heroes/Home';
 import ModuleGrid from '~/components/modules/ModuleGrid';
-import {usePreviewComponent, usePreviewContext} from '~/lib/preview';
+import {usePreviewComponent, usePreviewContext} from '~/lib/sanity';
+import {SanityHeroHome, SanityHomePage} from '~/lib/sanity';
 import {getStorefrontData, validateLocale} from '~/lib/utils';
 import {HOME_PAGE_QUERY} from '~/queries/sanity/home';
-import {SanityHeroHome, SanityHomePage} from '~/types/sanity';
 
 const seo: SeoHandleFunction = ({data}) => ({
   title: data?.page?.seo?.title || 'Sanity x Hydrogen',

--- a/app/routes/($lang)._index.tsx
+++ b/app/routes/($lang)._index.tsx
@@ -24,9 +24,16 @@ export const handle = {
 export async function loader({context, params}: LoaderArgs) {
   validateLocale({context, params});
 
-  const page = await context.sanity.client.fetch<SanityHomePage>(
-    HOME_PAGE_QUERY,
-  );
+  const cache = context.storefront.CacheCustom({
+    mode: 'public',
+    maxAge: 60,
+    staleWhileRevalidate: 60,
+  });
+
+  const page = await context.sanity.fetchWithCache<SanityHomePage>({
+    query: HOME_PAGE_QUERY,
+    cache,
+  });
 
   // Resolve any references to products on the Storefront API
   const storefrontData = await getStorefrontData({page, context});

--- a/app/routes/($lang).api.collections.$handle.tsx
+++ b/app/routes/($lang).api.collections.$handle.tsx
@@ -15,7 +15,7 @@ export async function loader({params, context, request}: LoaderArgs) {
   const count = searchParams.get('count');
 
   const {collection}: {collection: CollectionType} =
-    await context.storefront.query(COLLECTION_QUERY, {
+    await context.storefront.query<any>(COLLECTION_QUERY, {
       variables: {
         handle,
         cursor,

--- a/app/routes/($lang).collections.$handle.tsx
+++ b/app/routes/($lang).collections.$handle.tsx
@@ -54,7 +54,7 @@ export async function loader({params, context, request}: LoaderArgs) {
   });
 
   const [page, {collection}] = await Promise.all([
-    context.sanity.fetchWithCache<SanityCollectionPage>({
+    context.sanity.query<SanityCollectionPage>({
       query: COLLECTION_PAGE_QUERY,
       params: {
         slug: params.handle,

--- a/app/routes/($lang).collections.$handle.tsx
+++ b/app/routes/($lang).collections.$handle.tsx
@@ -8,10 +8,10 @@ import ProductGrid from '~/components/collection/ProductGrid';
 import SortOrder from '~/components/collection/SortOrder';
 import {SORT_OPTIONS} from '~/components/collection/SortOrder';
 import CollectionHero from '~/components/heroes/Collection';
+import {SanityCollectionPage} from '~/lib/sanity';
 import {getStorefrontData, notFound, validateLocale} from '~/lib/utils';
 import {COLLECTION_PAGE_QUERY} from '~/queries/sanity/collection';
 import {COLLECTION_QUERY} from '~/queries/shopify/collection';
-import {SanityCollectionPage} from '~/types/sanity';
 
 const seo: SeoHandleFunction<typeof loader> = ({data}) => ({
   title: data?.page?.seo?.title ?? data?.collection?.title,

--- a/app/routes/($lang).collections.$handle.tsx
+++ b/app/routes/($lang).collections.$handle.tsx
@@ -47,9 +47,19 @@ export async function loader({params, context, request}: LoaderArgs) {
 
   invariant(params.handle, 'Missing collection handle');
 
+  const cache = context.storefront.CacheCustom({
+    mode: 'public',
+    maxAge: 60,
+    staleWhileRevalidate: 60,
+  });
+
   const [page, {collection}] = await Promise.all([
-    context.sanity.client.fetch<SanityCollectionPage>(COLLECTION_PAGE_QUERY, {
-      slug: params.handle,
+    context.sanity.fetchWithCache<SanityCollectionPage>({
+      query: COLLECTION_PAGE_QUERY,
+      params: {
+        slug: params.handle,
+      },
+      cache,
     }),
     context.storefront.query<{collection: any}>(COLLECTION_QUERY, {
       variables: {

--- a/app/routes/($lang).pages.$handle.tsx
+++ b/app/routes/($lang).pages.$handle.tsx
@@ -32,7 +32,7 @@ export async function loader({params, context}: LoaderArgs) {
     staleWhileRevalidate: 60,
   });
 
-  const page = await context.sanity.fetchWithCache<SanityPage>({
+  const page = await context.sanity.query<SanityPage>({
     query: PAGE_QUERY,
     params: {
       slug: handle,

--- a/app/routes/($lang).pages.$handle.tsx
+++ b/app/routes/($lang).pages.$handle.tsx
@@ -6,9 +6,9 @@ import invariant from 'tiny-invariant';
 
 import PageHero from '~/components/heroes/Page';
 import PortableText from '~/components/portableText/PortableText';
+import {SanityPage} from '~/lib/sanity';
 import {getStorefrontData, notFound, validateLocale} from '~/lib/utils';
 import {PAGE_QUERY} from '~/queries/sanity/page';
-import {SanityPage} from '~/types/sanity';
 
 const seo: SeoHandleFunction<typeof loader> = ({data}) => ({
   title: data?.page?.seo?.title,

--- a/app/routes/($lang).pages.$handle.tsx
+++ b/app/routes/($lang).pages.$handle.tsx
@@ -26,8 +26,18 @@ export async function loader({params, context}: LoaderArgs) {
   const {handle} = params;
   invariant(handle, 'Missing page handle');
 
-  const page = await context.sanity.client.fetch<SanityPage>(PAGE_QUERY, {
-    slug: handle,
+  const cache = context.storefront.CacheCustom({
+    mode: 'public',
+    maxAge: 60,
+    staleWhileRevalidate: 60,
+  });
+
+  const page = await context.sanity.fetchWithCache<SanityPage>({
+    query: PAGE_QUERY,
+    params: {
+      slug: handle,
+    },
+    cache,
   });
 
   // Resolve any references to products on the Storefront API

--- a/app/routes/($lang).products.$handle.tsx
+++ b/app/routes/($lang).products.$handle.tsx
@@ -22,13 +22,13 @@ import invariant from 'tiny-invariant';
 import PortableText from '~/components/portableText/PortableText';
 import ProductDetails from '~/components/product/Details';
 import RelatedProducts from '~/components/product/RelatedProducts';
+import {SanityProductPage} from '~/lib/sanity';
 import {getStorefrontData, notFound, validateLocale} from '~/lib/utils';
 import {PRODUCT_PAGE_QUERY} from '~/queries/sanity/product';
 import {
   PRODUCT_QUERY,
   RECOMMENDED_PRODUCTS_QUERY,
 } from '~/queries/shopify/product';
-import {SanityProductPage} from '~/types/sanity';
 
 const seo: SeoHandleFunction = ({data}) => {
   const media = flattenConnection<MediaConnection>(data.product?.media).find(

--- a/app/routes/($lang).products.$handle.tsx
+++ b/app/routes/($lang).products.$handle.tsx
@@ -79,7 +79,7 @@ export async function loader({params, context, request}: LoaderArgs) {
   });
 
   const [page, {product}] = await Promise.all([
-    context.sanity.fetchWithCache<SanityProductPage>({
+    context.sanity.query<SanityProductPage>({
       query: PRODUCT_PAGE_QUERY,
       params: {
         slug: params.handle,

--- a/app/routes/($lang).products.$handle.tsx
+++ b/app/routes/($lang).products.$handle.tsx
@@ -72,9 +72,19 @@ export async function loader({params, context, request}: LoaderArgs) {
     selectedOptions.push({name, value});
   });
 
+  const cache = context.storefront.CacheCustom({
+    mode: 'public',
+    maxAge: 60,
+    staleWhileRevalidate: 60,
+  });
+
   const [page, {product}] = await Promise.all([
-    context.sanity.client.fetch<SanityProductPage>(PRODUCT_PAGE_QUERY, {
-      slug: params.handle,
+    context.sanity.fetchWithCache<SanityProductPage>({
+      query: PRODUCT_PAGE_QUERY,
+      params: {
+        slug: params.handle,
+      },
+      cache,
     }),
     context.storefront.query<{
       product: Product & {selectedVariant?: ProductVariant};

--- a/app/routes/[sitemap.xml].tsx
+++ b/app/routes/[sitemap.xml].tsx
@@ -21,17 +21,6 @@ type SanityPayload = {
   products: SitemapPage[];
 };
 
-// interface ProductEntry {
-//   url: string;
-//   lastMod: string;
-//   changeFreq: string;
-//   image?: {
-//     url: string;
-//     title?: string;
-//     caption?: string;
-//   };
-// }
-
 export async function loader({request, context: {sanity}}: LoaderArgs) {
   const baseUrl = new URL(request.url).origin;
   const data = await sanity.client.fetch<SanityPayload>(QUERY_SANITY, {

--- a/app/routes/api.preview.tsx
+++ b/app/routes/api.preview.tsx
@@ -38,7 +38,7 @@ export const action: ActionFunction = async ({request, context}) => {
 export const loader: LoaderFunction = async function ({request, context}) {
   const {env, sanity} = context;
   if (!sanity.preview?.session) {
-    throw notFound();
+    return notFound();
   }
 
   const {searchParams} = new URL(request.url);

--- a/app/routes/api.preview.tsx
+++ b/app/routes/api.preview.tsx
@@ -5,13 +5,16 @@ import {
   redirect,
 } from '@shopify/remix-oxygen';
 
+import {notFound} from '~/lib/utils';
+
 const ROOT_PATH = '/' as const;
 
 /**
  * A `POST` request to this route will exit preview mode
  */
 export const action: ActionFunction = async ({request, context}) => {
-  if (request.method !== 'POST') {
+  const {preview} = context.sanity;
+  if (request.method !== 'POST' || !preview?.session) {
     return json({message: 'Method not allowed'}, 405);
   }
 
@@ -21,7 +24,7 @@ export const action: ActionFunction = async ({request, context}) => {
 
   return redirect(slug, {
     headers: {
-      'Set-Cookie': await context.sanity.previewSession.destroy(),
+      'Set-Cookie': await preview.session.destroy(),
     },
   });
 };
@@ -34,6 +37,10 @@ export const action: ActionFunction = async ({request, context}) => {
  */
 export const loader: LoaderFunction = async function ({request, context}) {
   const {env, sanity} = context;
+  if (!sanity.preview?.session) {
+    throw notFound();
+  }
+
   const {searchParams} = new URL(request.url);
 
   if (!searchParams.has('secret')) {
@@ -47,12 +54,12 @@ export const loader: LoaderFunction = async function ({request, context}) {
   let slug = searchParams.get('slug') ?? ROOT_PATH;
   slug = slug.startsWith(ROOT_PATH) ? slug : ROOT_PATH;
 
-  sanity.previewSession.set('projectId', env.SANITY_PROJECT_ID);
+  sanity.preview.session.set('projectId', env.SANITY_PROJECT_ID);
 
   return redirect(slug, {
     status: 307,
     headers: {
-      'Set-Cookie': await sanity.previewSession.commit(),
+      'Set-Cookie': await sanity.preview.session.commit(),
     },
   });
 };

--- a/app/types/shopify.ts
+++ b/app/types/shopify.ts
@@ -1,4 +1,7 @@
-import type {Storefront as HydrogenStorefront} from '@shopify/hydrogen';
+import type {
+  CacheShort,
+  Storefront as HydrogenStorefront,
+} from '@shopify/hydrogen';
 import type {
   Collection,
   CountryCode,
@@ -71,3 +74,19 @@ export type ProductWithNodes = Partial<Omit<Product, 'media' | 'variants'>> & {
     nodes: ProductVariantConnection['nodes'];
   };
 };
+
+export type EnvironmentOptions = {
+  /**
+   * A Cache API instance.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Cache
+   */
+  cache: Cache;
+  /**
+   * A runtime utility for serverless environments
+   * @see https://developers.cloudflare.com/workers/runtime-apis/fetch-event/#waituntil
+   */
+  waitUntil: ExecutionContext['waitUntil'];
+};
+
+/** @see https://shopify.dev/docs/custom-storefronts/hydrogen/data-fetching/cache#caching-strategies */
+export type CachingStrategy = ReturnType<typeof CacheShort>;

--- a/remix.env.d.ts
+++ b/remix.env.d.ts
@@ -6,6 +6,13 @@ import type {Storefront} from '~/types/shopify';
 import type {SanityClient} from '@sanity/client';
 import type {HydrogenSession} from '../server';
 import type {PreviewSession} from '~/lib/preview';
+import type {Cache} from '@shopify/hydrogen';
+
+type useSanityQuery = {
+  query: string;
+  params?: Record<string, unknown>;
+  cache?: Cache;
+};
 
 type Sanity = {
   client: SanityClient;
@@ -15,6 +22,7 @@ type Sanity = {
     token: string;
   };
   previewSession: PreviewSession;
+  fetchWithCache<Any>(options: useSanityQuery): Promise<R>;
 };
 
 declare global {
@@ -47,6 +55,7 @@ declare global {
 declare module '@shopify/remix-oxygen' {
   export interface AppLoadContext {
     session: HydrogenSession;
+    waitUntil: ExecutionContext['waitUntil'];
     storefront: Storefront;
     env: Env;
     sanity: Sanity;

--- a/remix.env.d.ts
+++ b/remix.env.d.ts
@@ -22,7 +22,7 @@ type Sanity = {
     token: string;
   };
   previewSession: PreviewSession;
-  fetchWithCache<Any>(options: useSanityQuery): Promise<R>;
+  query<Any>(options: useSanityQuery): Promise<R>;
 };
 
 declare global {

--- a/remix.env.d.ts
+++ b/remix.env.d.ts
@@ -3,27 +3,9 @@
 /// <reference types="@shopify/oxygen-workers-types" />
 
 import type {Storefront} from '~/types/shopify';
-import type {SanityClient} from '@sanity/client';
 import type {HydrogenSession} from '../server';
-import type {PreviewSession} from '~/lib/preview';
+import type {PreviewSession, Sanity} from '~/lib/sanity';
 import type {Cache} from '@shopify/hydrogen';
-
-type useSanityQuery = {
-  query: string;
-  params?: Record<string, unknown>;
-  cache?: Cache;
-};
-
-type Sanity = {
-  client: SanityClient;
-  preview?: {
-    projectId: string;
-    dataset: string;
-    token: string;
-  };
-  previewSession: PreviewSession;
-  query<Any>(options: useSanityQuery): Promise<R>;
-};
 
 declare global {
   /**

--- a/server.ts
+++ b/server.ts
@@ -55,10 +55,13 @@ export default {
         cache,
         waitUntil,
         // Optionally, pass session and token to enable live-preview
-        preview: {
-          session: previewSession,
-          token: env.SANITY_API_TOKEN,
-        },
+        preview:
+          env.SANITY_PREVIEW_SECRET && env.SANITY_API_TOKEN
+            ? {
+                session: previewSession,
+                token: env.SANITY_API_TOKEN,
+              }
+            : undefined,
         // Pass configuration options for Sanity client
         config: {
           projectId: env.SANITY_PROJECT_ID,

--- a/server.ts
+++ b/server.ts
@@ -75,7 +75,7 @@ export default {
           useCdn: process.env.NODE_ENV === 'production',
         }),
         previewSession,
-        fetchWithCache: ({query, params, cache = CacheLong()}) => {
+        query: ({query, params, cache = CacheLong()}) => {
           // Prefix the cache key and make it unique based on arguments.
           return withCache(['sanity', query, params], cache, () => {
             return sanity.client.fetch(query, params);
@@ -111,7 +111,7 @@ export default {
           token,
         });
 
-        sanity.fetchWithCache = ({query, params}) => {
+        sanity.query = ({query, params}) => {
           return sanity.client.fetch(query, params);
         };
       }


### PR DESCRIPTION
Shopify have recently added an experimental `createWithCache_unstable` utility which facilitates caching for queries to third parties such as Sanity.

In order to improve performance and reduce API calls made to Sanity, this PR adds a `fetchWithCache` utility to the `sanity` context, which wraps around the `createWithCache_unstable` utility. This doesn't apply in preview mode.

The `cache` parameter accepts a Hydrogen caching strategy, and defaults to `CacheLong()` if none is provided.