### PR TITLE
Fix/missing layout

### DIFF
--- a/app/components/global/Footer.tsx
+++ b/app/components/global/Footer.tsx
@@ -14,7 +14,7 @@ export default function Footer() {
   const [root] = useMatches();
 
   const layout = root.data?.layout;
-  const {footer} = layout;
+  const {footer} = layout || {};
 
   const renderLinks = footer?.links?.map((link: SanityLink) => {
     if (link._type === 'linkExternal') {

--- a/app/components/global/Header.tsx
+++ b/app/components/global/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
   const [root] = useMatches();
 
   const layout = root.data?.layout;
-  const {menuLinks} = layout;
+  const {menuLinks} = layout || {};
 
   return (
     <header

--- a/app/components/global/NotFound.tsx
+++ b/app/components/global/NotFound.tsx
@@ -15,7 +15,7 @@ export function NotFound({
   notFoundCollection,
 }: {
   notFoundPage: SanityNotFoundPage;
-  notFoundCollection: Promise<{collection: Collection}>;
+  notFoundCollection?: Promise<{collection: Collection}>;
 }) {
   return (
     <div className="pt-34">
@@ -26,40 +26,41 @@ export function NotFound({
       <p className="my-8 text-center">
         {notFoundPage?.body || "We couldn't find the page you're looking for."}
       </p>
-
-      <div className="mx-4 mb-18 grid gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-        <Suspense
-          fallback={
-            <>
-              {Array(16)
-                .fill(true)
-                .map((_, i) => (
-                  // eslint-disable-next-line react/no-array-index-key
-                  <PillSkeleton key={i} />
-                ))}
-            </>
-          }
-        >
-          <Await
-            resolve={notFoundCollection}
-            errorElement={<p>Error loading products!</p>}
-          >
-            {({collection}: {collection: Collection}) => {
-              const products = flattenConnection(collection.products);
-
-              return (
-                <>
-                  {products?.map((product) => (
-                    <div key={product.id}>
-                      <ProductPill storefrontProduct={product} />
-                    </div>
+      {notFoundCollection && (
+        <div className="mx-4 mb-18 grid gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          <Suspense
+            fallback={
+              <>
+                {Array(16)
+                  .fill(true)
+                  .map((_, i) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <PillSkeleton key={i} />
                   ))}
-                </>
-              );
-            }}
-          </Await>
-        </Suspense>
-      </div>
+              </>
+            }
+          >
+            <Await
+              resolve={notFoundCollection}
+              errorElement={<p>Error loading products!</p>}
+            >
+              {({collection}: {collection: Collection}) => {
+                const products = flattenConnection(collection.products);
+
+                return (
+                  <>
+                    {products?.map((product) => (
+                      <div key={product.id}>
+                        <ProductPill storefrontProduct={product} />
+                      </div>
+                    ))}
+                  </>
+                );
+              }}
+            </Await>
+          </Suspense>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/lib/sanity/client.ts
+++ b/app/lib/sanity/client.ts
@@ -45,9 +45,9 @@ export function createSanityClient(options: CreateSanityClientOptions): Sanity {
     client: createClient(config),
     query: ({query, params, cache = CacheLong()}) => {
       // Prefix the cache key and make it unique based on arguments.
-      // return withCache(['sanity', query, params], cache, () => {
-      return sanity.client.fetch(query, params);
-      // });
+      return withCache(['sanity', query, params], cache, () => {
+        return sanity.client.fetch(query, params);
+      });
     },
   };
 

--- a/app/lib/sanity/client.ts
+++ b/app/lib/sanity/client.ts
@@ -45,9 +45,9 @@ export function createSanityClient(options: CreateSanityClientOptions): Sanity {
     client: createClient(config),
     query: ({query, params, cache = CacheLong()}) => {
       // Prefix the cache key and make it unique based on arguments.
-      return withCache(['sanity', query, params], cache, () => {
-        return sanity.client.fetch(query, params);
-      });
+      // return withCache(['sanity', query, params], cache, () => {
+      return sanity.client.fetch(query, params);
+      // });
     },
   };
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -41,7 +41,9 @@ import type {I18nLocale} from '~/types/shopify';
 
 const seo: SeoHandleFunction<typeof loader> = ({data}) => ({
   title: data?.layout?.seo?.title,
-  titleTemplate: `%s · ${data?.layout?.seo?.title}`,
+  titleTemplate: `%s${
+    data?.layout?.seo?.title ? ` · ${data?.layout?.seo?.title}` : ''
+  }`,
   description: data?.layout?.seo?.description,
 });
 
@@ -110,7 +112,7 @@ export async function loader({context}: LoaderArgs) {
     },
     cart: cartId ? getCart(context, cartId) : undefined,
     layout,
-    notFoundCollection: layout.notFoundPage?.collectionGid
+    notFoundCollection: layout?.notFoundPage?.collectionGid
       ? context.storefront.query<{collection: Collection}>(
           COLLECTION_QUERY_ID,
           {
@@ -189,37 +191,27 @@ export function ErrorBoundary({error}: {error: Error}) {
         <Links />
       </head>
       <body>
-        {layout ? (
-          <Layout
-            key={`${locale.language}-${locale.country}`}
-            backgroundColor={notFoundPage?.colorTheme?.background}
-          >
-            {isRouteError ? (
-              <>
-                {routeError.status === 404 ? (
-                  <NotFound
-                    notFoundPage={notFoundPage}
-                    notFoundCollection={notFoundCollection}
-                  />
-                ) : (
-                  <GenericError
-                    error={{message: `${routeError.status} ${routeError.data}`}}
-                  />
-                )}
-              </>
-            ) : (
-              <GenericError
-                error={error instanceof Error ? error : undefined}
-              />
-            )}
-          </Layout>
-        ) : (
-          <GenericError
-            error={{
-              message: 'No layout data available was found from Sanity.',
-            }}
-          />
-        )}
+        <Layout
+          key={`${locale.language}-${locale.country}`}
+          backgroundColor={notFoundPage?.colorTheme?.background}
+        >
+          {isRouteError ? (
+            <>
+              {routeError.status === 404 ? (
+                <NotFound
+                  notFoundPage={notFoundPage}
+                  notFoundCollection={notFoundCollection}
+                />
+              ) : (
+                <GenericError
+                  error={{message: `${routeError.status} ${routeError.data}`}}
+                />
+              )}
+            </>
+          ) : (
+            <GenericError error={error instanceof Error ? error : undefined} />
+          )}
+        </Layout>
         <Scripts nonce={nonce} />
       </body>
     </html>

--- a/app/routes/($lang)._index.tsx
+++ b/app/routes/($lang)._index.tsx
@@ -7,7 +7,7 @@ import HomeHero from '~/components/heroes/Home';
 import ModuleGrid from '~/components/modules/ModuleGrid';
 import {usePreviewComponent, usePreviewContext} from '~/lib/sanity';
 import {SanityHeroHome, SanityHomePage} from '~/lib/sanity';
-import {getStorefrontData, validateLocale} from '~/lib/utils';
+import {getStorefrontData, notFound, validateLocale} from '~/lib/utils';
 import {HOME_PAGE_QUERY} from '~/queries/sanity/home';
 
 const seo: SeoHandleFunction = ({data}) => ({
@@ -34,6 +34,10 @@ export async function loader({context, params}: LoaderArgs) {
     query: HOME_PAGE_QUERY,
     cache,
   });
+
+  if (!page) {
+    throw notFound();
+  }
 
   // Resolve any references to products on the Storefront API
   const storefrontData = await getStorefrontData({page, context});


### PR DESCRIPTION
This PR adds better handling for a missing "settings" document in Sanity. Rather than rendering failing and a hard to solve error being presented, the layout will still render with missing content.

Additionally, a missing home page document will now return a 404 error.

Closes #44 