### PR TITLE
chore: upgrade to latest Hydrogen, update Image components

### DIFF
--- a/app/components/account/OrderCard.tsx
+++ b/app/components/account/OrderCard.tsx
@@ -33,9 +33,8 @@ export function OrderCard({order}: Props) {
             className="fadeIn cover w-full"
             data={lineItems[0].variant?.image}
             height={168}
-            loaderOptions={{scale: 2, crop: 'center'}}
+            crop="center"
             width={168}
-            widths={[168]}
           />
         </div>
       )}

--- a/app/components/product/Card.tsx
+++ b/app/components/product/Card.tsx
@@ -66,7 +66,8 @@ export default function ProductCard({
             <Image
               className="absolute h-full w-full transform bg-cover bg-center object-cover object-center ease-in-out"
               data={firstVariant.image}
-              loaderOptions={{crop: 'center'}}
+              crop="center"
+              sizes="100%"
             />
           )}
 

--- a/app/components/product/Gallery.tsx
+++ b/app/components/product/Gallery.tsx
@@ -113,7 +113,9 @@ export default function ProductGallery({
                 draggable={false}
                 key={med.id}
                 tabIndex={0}
-                mediaOptions={{image: {loaderOptions: {crop: 'center'}}}}
+                mediaOptions={{
+                  image: {crop: 'center', sizes: '100vw', loading: 'eager'},
+                }}
                 {...extraProps}
               />
             );

--- a/app/components/product/Pill.tsx
+++ b/app/components/product/Pill.tsx
@@ -67,7 +67,8 @@ export default function ProductPill({
                   !availableForSale && 'opacity-50',
                 )}
                 data={image}
-                loaderOptions={{height: 200, crop: 'center'}}
+                crop="center"
+                width="110px"
               />
             )}
 

--- a/app/components/product/ProductHero.tsx
+++ b/app/components/product/ProductHero.tsx
@@ -31,6 +31,7 @@ export default function ProductHero({gid, variantGid}: Props) {
         <Image
           className="absolute h-full w-full transform bg-cover bg-center object-cover object-center"
           data={firstVariant.image}
+          sizes="100vw"
         />
       )}
 

--- a/app/components/product/Tooltip.tsx
+++ b/app/components/product/Tooltip.tsx
@@ -1,5 +1,4 @@
 import {Image, Money, type ShopifyAnalyticsProduct} from '@shopify/hydrogen';
-import type {Image as ImageType} from '@shopify/hydrogen/storefront-api-types';
 import clsx from 'clsx';
 
 import Badge from '~/components/elements/Badge';
@@ -60,14 +59,15 @@ export default function ProductTooltip({
           {selectedVariant.image && (
             <Image
               className="absolute h-full w-full transform bg-cover bg-center object-cover object-center ease-in-out"
-              data={selectedVariant.image as ImageType}
+              data={selectedVariant.image}
+              aspectRatio="1/1"
             />
           )}
           {/* Badges */}
           <div className="absolute left-4 top-4">
             {/* Sale */}
             {selectedVariant?.availableForSale &&
-              selectedVariant?.compareAtPriceV2 && (
+              selectedVariant?.compareAtPrice && (
                 <Badge label="Sale" tone="critical" />
               )}
             {/* Sold out */}

--- a/app/routes/($lang).account.orders.$id.tsx
+++ b/app/routes/($lang).account.orders.$id.tsx
@@ -149,16 +149,11 @@ export default function OrderRoute() {
                             {lineItem?.variant?.image && (
                               <div className="aspect-square w-20 overflow-hidden rounded-sm">
                                 <Image
-                                  data={{
-                                    url: lineItem.variant.image.src!,
-                                  }}
+                                  data={lineItem.variant.image!}
                                   width={lineItem.variant.image.width!}
                                   height={lineItem.variant.image.height!}
                                   alt={lineItem.variant.image.altText!}
-                                  loaderOptions={{
-                                    scale: 2,
-                                    crop: 'center',
-                                  }}
+                                  crop="center"
                                 />
                               </div>
                             )}
@@ -245,7 +240,7 @@ export default function OrderRoute() {
                       <p>Subtotal</p>
                     </th>
                     <td className="pl-3 pr-4 pt-6 text-right md:pr-3">
-                      <Money data={order.subtotalPriceV2!} />
+                      <Money data={order.subtotalPrice!} />
                     </td>
                   </tr>
                   <tr>
@@ -263,7 +258,7 @@ export default function OrderRoute() {
                       <p>Tax</p>
                     </th>
                     <td className="pl-3 pr-4 pt-4 text-right md:pr-3">
-                      <Money data={order.totalTaxV2!} />
+                      <Money data={order.totalTax!} />
                     </td>
                   </tr>
                   <tr>
@@ -281,7 +276,7 @@ export default function OrderRoute() {
                       <p>Total</p>
                     </th>
                     <td className="pl-3 pr-4 pt-4 text-right font-bold md:pr-3">
-                      <Money data={order.totalPriceV2!} />
+                      <Money data={order.totalPrice!} />
                     </td>
                   </tr>
                 </tfoot>
@@ -371,7 +366,7 @@ const CUSTOMER_ORDER_QUERY = `#graphql
   fragment Image on Image {
     altText
     height
-    src: url(transform: {crop: CENTER, maxHeight: 96, maxWidth: 96, scale: 2})
+    url: url(transform: {crop: CENTER, maxHeight: 96, maxWidth: 96, scale: 2})
     id
     width
   }
@@ -423,13 +418,13 @@ const CUSTOMER_ORDER_QUERY = `#graphql
         orderNumber
         processedAt
         fulfillmentStatus
-        totalTaxV2 {
+        totalTax {
           ...Money
         }
-        totalPriceV2 {
+        totalPrice {
           ...Money
         }
-        subtotalPriceV2 {
+        subtotalPrice {
           ...Money
         }
         shippingAddress {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@sanity/types": "^3.9.0",
         "@shopify/cli": "3.45.1",
         "@shopify/cli-hydrogen": "^4.1.0",
-        "@shopify/hydrogen": "^2023.1.7",
+        "@shopify/hydrogen": "^2023.4.0",
         "@shopify/remix-oxygen": "^1.0.5",
         "@tippyjs/react": "^4.2.6",
         "clsx": "^1.2.1",
@@ -3283,9 +3283,9 @@
       }
     },
     "node_modules/@shopify/cli-hydrogen": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shopify/cli-hydrogen/-/cli-hydrogen-4.1.0.tgz",
-      "integrity": "sha512-7puM8tQ9UwFqZOXbcaucBQ6jAyQmyNd+crdfiG9Jxyk2rTNdRyiHFuJfmpfVwweqlPRq4Ff31dchYnag7uSXGA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@shopify/cli-hydrogen/-/cli-hydrogen-4.1.1.tgz",
+      "integrity": "sha512-Z0V1wBYjOglfNkNu303A7eStVUhyuhhF8yDwcqPVIfUxP/gQRn34WjnHexchjZDraRcnxJioAABFpB8yvyJT0A==",
       "dependencies": {
         "@oclif/core": "2.1.4",
         "@remix-run/dev": "1.15.0",
@@ -3308,7 +3308,7 @@
       },
       "peerDependencies": {
         "@remix-run/react": "^1.15.0",
-        "@shopify/hydrogen-react": "^2023.1.8",
+        "@shopify/hydrogen-react": "^2023.4.0",
         "@shopify/remix-oxygen": "^1.0.5"
       }
     },
@@ -3965,11 +3965,11 @@
       }
     },
     "node_modules/@shopify/hydrogen": {
-      "version": "2023.1.7",
-      "resolved": "https://registry.npmjs.org/@shopify/hydrogen/-/hydrogen-2023.1.7.tgz",
-      "integrity": "sha512-tzP52gLMzBxCg0ZndZYh39bmguOWdbMO7rcTbaPQXHgus3nOKp7byavWgI9obsgxgp++ugeCqF8AlTdBFEAu4A==",
+      "version": "2023.4.0",
+      "resolved": "https://registry.npmjs.org/@shopify/hydrogen/-/hydrogen-2023.4.0.tgz",
+      "integrity": "sha512-dHXaa8unSY17wCYdXNU83rSzEcmc7ojdCPAqSoX3hlLv6jmaBd+Mvq+VrWMnHtxQ7E/oTtUWa9k82oA23hVOaw==",
       "dependencies": {
-        "@shopify/hydrogen-react": "2023.1.8",
+        "@shopify/hydrogen-react": "2023.4.0",
         "react": "^18.2.0"
       },
       "peerDependencies": {
@@ -3978,9 +3978,9 @@
       }
     },
     "node_modules/@shopify/hydrogen-react": {
-      "version": "2023.1.8",
-      "resolved": "https://registry.npmjs.org/@shopify/hydrogen-react/-/hydrogen-react-2023.1.8.tgz",
-      "integrity": "sha512-OP3URjwlbAsST49Gwo2JGxNq7JrHg8wJtXxOx/vjXgteJekmRqKzwDiJUR85OPbVnIp6KVOoy3aWjIFiBBmfpg==",
+      "version": "2023.4.0",
+      "resolved": "https://registry.npmjs.org/@shopify/hydrogen-react/-/hydrogen-react-2023.4.0.tgz",
+      "integrity": "sha512-/4kiMOlhEdisBY/qACypfCmYmKtbS8/ywjo40ldTf+ZVJSniR9RXqSiKEeFD1/1bRsLctAHCZvDI9ysaIJS1Mg==",
       "dependencies": {
         "@google/model-viewer": "^1.12.1",
         "@xstate/fsm": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@sanity/types": "^3.9.0",
     "@shopify/cli": "3.45.1",
     "@shopify/cli-hydrogen": "^4.1.0",
-    "@shopify/hydrogen": "^2023.1.7",
+    "@shopify/hydrogen": "^2023.4.0",
     "@shopify/remix-oxygen": "^1.0.5",
     "@tippyjs/react": "^4.2.6",
     "clsx": "^1.2.1",


### PR DESCRIPTION
This updates to the latest Hydrogen version, and takes advantage of the new Hydrogen `<Image />` component for images delivered from Shopify's CDN.