### PR TITLE
fix: fixes for adding content in live preview

### DIFF
--- a/app/components/elements/LinkButton.tsx
+++ b/app/components/elements/LinkButton.tsx
@@ -17,6 +17,10 @@ export default function LinkButton({
   link,
   textColor,
 }: Props) {
+  if (!link.title) {
+    return null;
+  }
+
   return (
     <Link
       className={clsx(defaultButtonStyles(), className)}

--- a/app/components/modules/Instagram.tsx
+++ b/app/components/modules/Instagram.tsx
@@ -13,6 +13,10 @@ export default function InstagramModule({
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
+  if (!module.url) {
+    return null;
+  }
+
   return (
     <div className="mx-auto min-h-full max-w-[400px] overflow-hidden">
       {mounted && <InstagramEmbed url={module.url} />}

--- a/app/components/modules/Product.tsx
+++ b/app/components/modules/Product.tsx
@@ -16,8 +16,8 @@ export default function ProductModule({
   layout = 'card',
   module,
 }: Props) {
-  const productGid = module?.productWithVariant.gid;
-  const productVariantGid = module?.productWithVariant.variantGid;
+  const productGid = module?.productWithVariant?.gid;
+  const productVariantGid = module?.productWithVariant?.variantGid;
   const storefrontProduct = useGid<Product>(productGid);
 
   if (!storefrontProduct) {

--- a/app/components/portableText/annotations/LinkExternal.tsx
+++ b/app/components/portableText/annotations/LinkExternal.tsx
@@ -10,7 +10,7 @@ type Props = PortableTextMarkComponentProps & {
 
 const LinkExternalAnnotation = ({children, value}: Props) => {
   if (!value?.url) {
-    return null;
+    return <>{children}</>;
   }
 
   return (

--- a/app/components/portableText/annotations/Product.tsx
+++ b/app/components/portableText/annotations/Product.tsx
@@ -16,11 +16,11 @@ type Props = PortableTextMarkComponentProps & {
 const ProductAnnotation = ({children, value}: Props) => {
   const {productWithVariant} = value;
 
-  const productGid = productWithVariant.gid;
-  const productVariantGid = productWithVariant.variantGid;
+  const productGid = productWithVariant?.gid;
+  const productVariantGid = productWithVariant?.variantGid;
   const storefrontProduct = useGid<Product>(productGid);
 
-  if (!storefrontProduct) {
+  if (!productGid || !storefrontProduct) {
     return <>{children}</>;
   }
 

--- a/app/components/portableText/blocks/Images.tsx
+++ b/app/components/portableText/blocks/Images.tsx
@@ -10,6 +10,10 @@ type Props = {
 };
 
 export default function ImagesBlock({centered, value}: Props) {
+  if (!Array.isArray(value.modules)) {
+    return null;
+  }
+
   const multipleImages = value.modules.length > 1;
   let alignClass;
   switch (value.verticalAlign) {

--- a/app/components/portableText/blocks/Instagram.tsx
+++ b/app/components/portableText/blocks/Instagram.tsx
@@ -8,6 +8,10 @@ type Props = {
 };
 
 export default function InstagramBlock({value}: Props) {
+  if (!value) {
+    return null;
+  }
+
   return (
     <div
       className={clsx(

--- a/app/components/portableText/blocks/Products.tsx
+++ b/app/components/portableText/blocks/Products.tsx
@@ -9,6 +9,10 @@ type Props = {
 };
 
 export default function ProductsBlock({value}: Props) {
+  if (!Array.isArray(value?.modules)) {
+    return null;
+  }
+
   const multipleProducts = value.modules.length > 1;
 
   return (

--- a/app/components/product/Tag.tsx
+++ b/app/components/product/Tag.tsx
@@ -12,6 +12,10 @@ type Props = {
 };
 
 export default function ProductTag({storefrontProduct, variantGid}: Props) {
+  if (!storefrontProduct) {
+    return null;
+  }
+
   const {handle, title} = storefrontProduct;
 
   return (

--- a/app/queries/sanity/collection.ts
+++ b/app/queries/sanity/collection.ts
@@ -6,7 +6,7 @@ export const COLLECTION_PAGE_QUERY = groq`
   *[
     _type == 'collection'
     && store.slug.current == $slug
-  ][0]{
+  ] | order(_updatedAt desc) [0]{
     ${COLLECTION_PAGE}
   }
 `;

--- a/app/queries/sanity/home.ts
+++ b/app/queries/sanity/home.ts
@@ -3,7 +3,7 @@ import groq from 'groq';
 import {HOME_PAGE} from './fragments/pages/home';
 
 export const HOME_PAGE_QUERY = groq`
-  *[_type == 'home'][0]{
+  *[_type == 'home'] | order(_updatedAt desc) [0]{
     ${HOME_PAGE}
   }
 `;

--- a/app/queries/sanity/layout.ts
+++ b/app/queries/sanity/layout.ts
@@ -5,7 +5,7 @@ import {LINKS} from './fragments/links';
 import {PORTABLE_TEXT} from './fragments/portableText/portableText';
 
 export const LAYOUT_QUERY = groq`
-  *[_type == 'settings'][0] {
+  *[_type == 'settings'] | order(_updatedAt desc) [0] {
     seo,
     "menuLinks": menu.links[] {
       ${LINKS}

--- a/app/queries/sanity/page.ts
+++ b/app/queries/sanity/page.ts
@@ -6,7 +6,7 @@ export const PAGE_QUERY = groq`
   *[
     _type == 'page'
     && slug.current == $slug
-  ][0]{
+  ] | order(_updatedAt desc) [0]{
     ${PAGE}
   }
 `;

--- a/app/queries/sanity/product.ts
+++ b/app/queries/sanity/product.ts
@@ -6,7 +6,7 @@ export const PRODUCT_PAGE_QUERY = groq`
   *[
     _type == 'product'
     && store.slug.current == $slug
-  ][0]{
+  ] | order(_updatedAt desc) [0]{
     ${PRODUCT_PAGE}
   }
 `;

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -11,6 +11,9 @@
     @apply text-offBlack;
     @apply text-md;
   }
+  body {
+    @apply bg-white;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
Fixes for numerous content types when adding content in live preview mode. Includes revalidation of data if updates include references to additional products on Shopify not currently in the data from the loader. Adds preview to page route.