### PR TITLE
fix: PT blocks, backwards compatible

### DIFF
--- a/app/components/portableText/PortableText.tsx
+++ b/app/components/portableText/PortableText.tsx
@@ -47,16 +47,16 @@ export default function PortableText({blocks, centered, className}: Props) {
     },
     block: Block,
     types: {
-      blockAccordion: AccordionBlock,
-      blockCallout: (props: any) => (
+      'module.accordion': AccordionBlock,
+      'module.callout': (props: any) => (
         <CalloutBlock centered={centered} {...props} />
       ),
-      blockGrid: GridBlock,
-      blockImages: (props: any) => (
+      'module.grid': GridBlock,
+      'module.images': (props: any) => (
         <ImagesBlock centered={centered} {...props} />
       ),
-      blockInstagram: InstagramBlock,
-      blockProducts: ProductsBlock,
+      'module.instagram': InstagramBlock,
+      'module.products': ProductsBlock,
     },
   };
 

--- a/app/queries/sanity/fragments/portableText/portableText.ts
+++ b/app/queries/sanity/fragments/portableText/portableText.ts
@@ -8,24 +8,31 @@ import {MODULE_INSTAGRAM} from '../modules/instagram';
 import {MODULE_PRODUCTS} from '../modules/products';
 import {MARK_DEFS} from './markDefs';
 
+// We check the _type for backwards compatibility with the old block type names.
 export const PORTABLE_TEXT = groq`
   ...,
-  (_type == 'blockAccordion') => {
+  (_type == 'blockAccordion' || _type == 'module.accordion') => {
+    '_type': 'module.accordion',
     ${MODULE_ACCORDION},
   },
-  (_type == 'blockCallout') => {
+  (_type == 'blockCallout' || _type == 'module.callout') => {
+    '_type': 'module.callout',
     ${MODULE_CALLOUT}
   },
-  (_type == 'blockGrid') => {
+  (_type == 'blockGrid' || _type == 'module.grid') => {
+    '_type': 'module.grid',
     ${MODULE_GRID},
   },
-  (_type == 'blockImages') => {
+  (_type == 'blockImages' || _type == 'module.images') => {
+    '_type': 'module.images',
     ${MODULE_IMAGES}
   },
-  (_type == 'blockInstagram') => {
+  (_type == 'blockInstagram' || _type == 'module.instagram') => {
+    '_type': 'module.instagram',
     ${MODULE_INSTAGRAM}
   },
-  (_type == 'blockProducts') => {
+  (_type == 'blockProducts' || _type == 'module.products') => {
+    '_type': 'module.products',
     ${MODULE_PRODUCTS}
   },
   markDefs[] {


### PR DESCRIPTION
Updates in line with [Studio updates to support GraphQL](https://github.com/sanity-io/sanity-shopify-studio/pull/31) - backwards compatible with both new and old data structures.